### PR TITLE
cpplint fixes

### DIFF
--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -141,7 +141,7 @@ class Utils {
     uint64_t i = 0;
 
     while (i < len) {
-      size_t curr = (size_t)str[i];
+      size_t curr = static_cast<size_t>(str[i]);
       if (curr > max_len) {
         max_len = curr;
       }
@@ -162,7 +162,7 @@ class Utils {
     uint64_t j = 0;
 
     while (i < len) {
-      size_t curr = (size_t)source[i];
+      size_t curr = static_cast<size_t>(source[i]);
       for (size_t k = 0; k < curr; ++k) {
         dest[j + k] = (wchar_t)source[i + pad_size + k];
       }


### PR DESCRIPTION
Cpplint 1.5.5 was released a couple hours ago (https://pypi.org/project/cpplint/) and
is flagging some additional issues in our code:

```
./src/utils.hpp:144:  Using C-style cast.  Use static_cast<size_t>(...) instead  [readability/casting] [4]
./src/utils.hpp:165:  Using C-style cast.  Use static_cast<size_t>(...) instead  [readability/casting] [4]
```

This has caused our CI to mark the last commit as failing
(https://github.com/NVIDIA-Merlin/nvtabular_triton_backend/runs/2631502752)

Fix.