### PR TITLE
Allow multiple models to run

### DIFF
--- a/src/backend.cc
+++ b/src/backend.cc
@@ -140,6 +140,9 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend) {
   py::initialize_interpreter();
   LOG_MESSAGE(TRITONSERVER_LOG_INFO, "Python interpreter is initialized");
 
+  // we have to manually release the GIL here otherwise we'll deadlock in future threads
+  PyEval_SaveThread();
+
   return nullptr;  // success
 }
 
@@ -148,7 +151,8 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend) {
 // state and perform any other global cleanup.
 TRITONSERVER_Error*
 TRITONBACKEND_Finalize(TRITONBACKEND_Backend* backend) {
-  // py::finalize_interpreter();
+  py::gil_scoped_acquire l;
+  py::finalize_interpreter();
 
   void* vstate;
   RETURN_IF_ERROR(TRITONBACKEND_BackendState(backend, &vstate));

--- a/src/model_inst_state.hpp
+++ b/src/model_inst_state.hpp
@@ -98,6 +98,7 @@ ModelInstanceState::Create(ModelState *model_state,
   RETURN_IF_ERROR(
       TRITONBACKEND_ModelInstanceDeviceId(triton_model_instance, &instance_id));
 
+  py::gil_scoped_acquire l;
   *state = new ModelInstanceState(model_state, triton_model_instance,
                                   instance_name, instance_kind, instance_id);
 

--- a/src/nvtabular.hpp
+++ b/src/nvtabular.hpp
@@ -139,6 +139,7 @@ class NVT_LOCAL NVTabular {
                  TRITONSERVER_DataType *input_dtypes,
                  const std::unordered_map<std::string, size_t> &max_str_sizes,
                  const std::vector<std::string> &output_names) {
+    py::gil_scoped_acquire l;
     py::list all_inputs;
     py::list all_inputs_names;
     for (uint32_t i = 0; i < input_names.size(); ++i) {


### PR DESCRIPTION
We weren't properly managing the GIL, causing issues with multiple threads.
Fix by releasing GIL immediately after creating the pytohn interprerter
and adding py::gil_scoped_acquire guards around python code access