### PR TITLE
Use PY_MAJOR_VERSION / PY_MINOR_VERSION constants for loading libpython

### DIFF
--- a/src/backend.cc
+++ b/src/backend.cc
@@ -137,6 +137,16 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend) {
   RETURN_IF_ERROR(
       TRITONBACKEND_BackendSetState(backend, reinterpret_cast<void*>(state)));
 
+  // Force opening of libpython - so that it's available globally for c-extension modules
+  std::stringstream python_lib;
+  python_lib << "libpython" << PY_MAJOR_VERSION << "." << PY_MINOR_VERSION << ".so";
+  void *handle = dlopen(python_lib.str().c_str(), RTLD_LAZY | RTLD_GLOBAL);
+  if (!handle) {
+    LOG_MESSAGE(TRITONSERVER_LOG_ERROR, dlerror());
+  } else {
+    LOG_MESSAGE(TRITONSERVER_LOG_INFO, "Loaded libpython successfully");
+  }
+
   py::initialize_interpreter();
   LOG_MESSAGE(TRITONSERVER_LOG_INFO, "Python interpreter is initialized");
 

--- a/src/model_state.hpp
+++ b/src/model_state.hpp
@@ -131,38 +131,6 @@ TRITONSERVER_Error *ModelState::Create(TRITONBACKEND_Model *triton_model,
   RETURN_IF_ERROR(
       TRITONBACKEND_ModelRepository(triton_model, &artifact_type, &path));
 
-  std::string python_version_path(path);
-  python_version_path.append("/");
-  python_version_path.append(std::to_string(model_version));
-  python_version_path.append("/workflow/metadata.json");
-
-  std::string line;
-  std::ifstream myfile(python_version_path.c_str());
-  if (myfile.is_open()) {
-    std::getline(myfile, line);
-    myfile.close();
-  }
-
-  rapidjson::Document document;
-  document.Parse(line.c_str());
-  if (document["versions"].HasMember("python")) {
-    std::string python_lib = "libpython";
-
-    std::string value(document["versions"]["python"].GetString());
-    python_lib.append(value.substr(0, 3));
-    python_lib.append(".so");
-
-    void *handle = dlopen(python_lib.c_str(), RTLD_LAZY | RTLD_GLOBAL);
-    if (!handle) {
-      LOG_MESSAGE(TRITONSERVER_LOG_ERROR, dlerror());
-    } else {
-      LOG_MESSAGE(TRITONSERVER_LOG_INFO, "Loaded libpython successfully");
-    }
-  } else {
-    LOG_MESSAGE(TRITONSERVER_LOG_ERROR,
-                "Python version is not specified in the metada.json");
-  }
-
   *state = new ModelState(triton_server, triton_model, model_name,
                           model_version, path, std::move(model_config));
   return nullptr;  // success


### PR DESCRIPTION
Instead of using the python version from the workflow model to load libpython,
use the versions from the PY_MAJOR_VERSION and PY_MINOR_VERSION constants
defined by the version of python we are building against.

This is slightly simpler and much less error prone: trying to dlopen a libpython that we didn't
build against will likely segfault, while in some cases (aside from python 3.7 -> 3.8)
we can run workflows saved by different versions of python with just a warning
generated from the version check https://github.com/NVIDIA/NVTabular/blob/2a51af02d428ab86ab34d8caf320e0e6b618dbd7/nvtabular/workflow.py#L255