### PR TITLE
Fix error handling

### DIFF
--- a/src/backend.cc
+++ b/src/backend.cc
@@ -184,7 +184,7 @@ TRITONBACKEND_ModelInstanceExecute(TRITONBACKEND_ModelInstance* instance, TRITON
   } catch (const std::exception & e) {
     // all requests failed (possibly a bug in the python model code). return errors for each
     // request and cleanup
-    LOG_MESSAGE(TRITONSERVER_LOG_ERROR, e.what());
+    LOG(TRITONSERVER_LOG_ERROR) << "Exception during transform_requests '" << e.what() << "'";
     auto err = TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, e.what());
 
     for (uint32_t i = 0; i < request_count; ++i) {
@@ -195,7 +195,11 @@ TRITONBACKEND_ModelInstanceExecute(TRITONBACKEND_ModelInstance* instance, TRITON
       LOG_IF_ERROR(TRITONBACKEND_RequestRelease(requests[i], TRITONSERVER_REQUEST_RELEASE_ALL),
                   "Failed to release request");
     }
-    return err;
+    // Note: we're purposefully not returning an Err here. (Doing so seems to segfault the
+    // tritonserver process when it tries to respond the error  UNLESS we also don't release
+    // the request (which means that on shutting down tritonserver is slow / maybe leaks memory ))
+    // Since we've already sent an error response w/ ResponseSend this seems to be ok
+    return nullptr;
   }
 }
 }  // extern "C"


### PR DESCRIPTION
We were seeing a problem where tritonserver would segfault if the python model
threw an exception - but since the segfault occurred after the error response
was sent the existing unittest worked. The problem seems to be returning an
error from TRITONBACKEND_ModelInstanceExecute causes tritonserver to try
to also send an error response back, but we've already closed the request
it fails. Not closing the request on error avoids the segfault, but causes
problems when shutting down tritonserver (it times out on shutdown since there
are still pending requests). So fix by returning success, which is fine since
we've already returned the error to the client.

Also change the unittest to detect this problem by running the error request multiple
times.