### PR TITLE
Add missing args to the model initialize call

### DIFF
--- a/src/model_inst_state.hpp
+++ b/src/model_inst_state.hpp
@@ -72,7 +72,11 @@ class NVT_LOCAL ModelInstanceState {
     py::dict args;
     args["model_config"] = model_state_->ModelConfig();
     args["model_version"] = model_state_->Version();
+    args["model_name"] = model_state_->Name();
     args["model_repository"] = model_state_->Path();
+    args["model_instance_kind"] = TRITONSERVER_InstanceGroupKindString(kind_);
+    args["model_instance_name"] = name_;
+    args["model_instance_device_id"] = std::to_string(device_id_);
     python_model.attr("initialize")(args);
   }
 


### PR DESCRIPTION
When initializing the model, the python backend was passing a couple of extra
arguments to initialize that we weren't including here. This included the
'model_instance_kind' which we need to detect whether to run on CPU or GPU.